### PR TITLE
Add Stateful compareAndSet Expr Function

### DIFF
--- a/cmd/batchforce/main.go
+++ b/cmd/batchforce/main.go
@@ -199,6 +199,8 @@ var RootCmd = &cobra.Command{
 	- escapeHtml: escapes characters using HTML entities like Apex's
 	  String.escapeHtml4 method
 	- base64: base-64 encodes input
+	- compareAndSet: check if key maps to value; if key doesn't exist, set it to
+	  value
 
 
 	Additional context to be provided to the Expr expression by passing the

--- a/expr.go
+++ b/expr.go
@@ -9,9 +9,8 @@ import (
 	strip "github.com/grokify/html-strip-tags-go"
 )
 
-var exprFunctions []expr.Option
-
-func init() {
+func exprFunctions() []expr.Option {
+	var exprFunctions []expr.Option
 	exprFunctions = append(exprFunctions, expr.Function(
 		"base64",
 		func(params ...any) (any, error) {
@@ -36,4 +35,27 @@ func init() {
 		new(func(string) string),
 	))
 
+	store := make(map[string]any)
+	// compareAndSet takes a key and value
+	// returns true if the key exists in the store and the stored value matches the passed value
+	// returns true if the key does not exist in the store, and stores the value under the key
+	// returns false if the key exists in the store and the stored value does not match the passed value
+	exprFunctions = append(exprFunctions, expr.Function(
+		"compareAndSet",
+		func(params ...any) (any, error) {
+			key := params[0].(string)
+			value := params[1]
+			if store[key] == value {
+				return true, nil
+			} else if _, ok := store[key]; !ok {
+				store[key] = value
+				return true, nil
+			} else {
+				return false, nil
+			}
+		},
+		new(func(string, any) bool),
+	))
+
+	return exprFunctions
 }

--- a/update.go
+++ b/update.go
@@ -208,7 +208,7 @@ func exprConverter(expression string, context any) func(force.ForceRecord) []for
 		"record": force.ForceRecord{},
 		"apex":   context,
 	}
-	program, err := expr.Compile(expression, append(exprFunctions, expr.Env(env))...)
+	program, err := expr.Compile(expression, append(exprFunctions(), expr.Env(env))...)
 	if err != nil {
 		log.Fatalln("Invalid expression:", err)
 	}


### PR DESCRIPTION
Add a stateful compareAndSet function that can be used across records.

compareAndSet takes a key and value
- returns true if the key exists in the store and the stored value
  matches the passed value
- returns true if the key does not exist in the store, and stores the
  value under the key
- returns false if the key exists in the store and the stored value does
  not match the passed value
