### PR TITLE
Add incr Expr Function

### DIFF
--- a/cmd/batchforce/main.go
+++ b/cmd/batchforce/main.go
@@ -201,6 +201,7 @@ var RootCmd = &cobra.Command{
 	- base64: base-64 encodes input
 	- compareAndSet: check if key maps to value; if key doesn't exist, set it to
 	  value
+	- incr: increments the number stored at key by one. set to 0 if not set.
 
 
 	Additional context to be provided to the Expr expression by passing the

--- a/expr.go
+++ b/expr.go
@@ -57,5 +57,22 @@ func exprFunctions() []expr.Option {
 		new(func(string, any) bool),
 	))
 
+	counters := make(map[string]int64)
+	// incr increments the number stored at key by one.  If the key does not
+	// exist, it is set to 0 first.
+	exprFunctions = append(exprFunctions, expr.Function(
+		"incr",
+		func(params ...any) (any, error) {
+			key := params[0].(string)
+			if v, ok := counters[key]; ok {
+				counters[key] = v + 1
+			} else {
+				counters[key] = 0
+			}
+			return counters[key], nil
+		},
+		new(func(string) int64),
+	))
+
 	return exprFunctions
 }


### PR DESCRIPTION
Add incr as a function that can be used in the expression.  incr
increments the number stored at key by one.  If the key does not
exist, it is set to 0 first.
