### PR TITLE
Add + Operator To Update ForceRecord

### DIFF
--- a/cmd/batchforce/main.go
+++ b/cmd/batchforce/main.go
@@ -335,6 +335,7 @@ var RootCmd = &cobra.Command{
 	  value
 	- incr: increments the number stored at key by one. set to 0 if not set.
 
+	The + operator can be used to add or update a field on the record object.
 
 	Additional context to be provided to the Expr expression by passing the
 	--context parameter containining anonymous apex to execute before the

--- a/expr.go
+++ b/expr.go
@@ -5,9 +5,19 @@ import (
 	"html"
 	"strings"
 
+	force "github.com/ForceCLI/force/lib"
 	"github.com/antonmedv/expr"
 	strip "github.com/grokify/html-strip-tags-go"
 )
+
+type Env map[string]any
+
+func (Env) MergePatch(a force.ForceRecord, b map[string]any) force.ForceRecord {
+	for k, v := range b {
+		a[k] = v
+	}
+	return a
+}
 
 func exprFunctions() []expr.Option {
 	var exprFunctions []expr.Option
@@ -73,6 +83,8 @@ func exprFunctions() []expr.Option {
 		},
 		new(func(string) int64),
 	))
+
+	exprFunctions = append(exprFunctions, expr.Operator("+", "MergePatch"))
 
 	return exprFunctions
 }

--- a/update.go
+++ b/update.go
@@ -244,7 +244,7 @@ func flattenRecord(r force.ForceRecord, subQueryRelationships map[string]bool) f
 }
 
 func exprConverter(expression string, context any) func(force.ForceRecord) []force.ForceRecord {
-	env := map[string]interface{}{
+	env := Env{
 		"record": force.ForceRecord{},
 		"apex":   context,
 	}
@@ -253,7 +253,7 @@ func exprConverter(expression string, context any) func(force.ForceRecord) []for
 		log.Fatalln("Invalid expression:", err)
 	}
 	converter := func(record force.ForceRecord) []force.ForceRecord {
-		env := map[string]interface{}{
+		env := Env{
 			"record": record,
 			"apex":   context,
 		}


### PR DESCRIPTION
Add supprot for + operator to expr expressions to add/update a field in
the `record`.  This is useful when records are loaded using `--file`,
but need to be modified before sending to Salesforce, to resolve a
RecordType Id, for example.
