### PR TITLE
Add --quiet Flag To Reduce Noise

### DIFF
--- a/cmd/batchforce/main.go
+++ b/cmd/batchforce/main.go
@@ -44,6 +44,7 @@ func init() {
 	RootCmd.AddCommand(versionCmd)
 
 	RootCmd.PersistentFlags().StringP("account", "a", "", "account `username` to use")
+	RootCmd.PersistentFlags().Bool("quiet", false, "supress informational log messages")
 }
 
 func main() {
@@ -267,6 +268,9 @@ var RootCmd = &cobra.Command{
 	},
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		initializeSession(cmd)
+		if quiet, _ := cmd.Flags().GetBool("quiet"); quiet {
+			log.SetLevel(log.WarnLevel)
+		}
 	},
 	DisableFlagsInUseLine: true,
 }
@@ -282,7 +286,7 @@ func cancelUponSignal(cancel context.CancelFunc) {
 			if interuptsReceived > 0 {
 				os.Exit(1)
 			}
-			log.Println("signal received.  cancelling.")
+			log.Warnln("signal received.  cancelling.")
 			cancel()
 			interuptsReceived++
 		}

--- a/execution.go
+++ b/execution.go
@@ -229,7 +229,7 @@ func (e *Execution) update(ctx context.Context, records <-chan force.ForceRecord
 		if err != nil {
 			return fmt.Errorf("Failed to serialize batch: %w", err)
 		}
-		log.Infof("Adding batch of %d records to job %s\n", len(batch), job.Id)
+		log.Infof("Adding batch of %d records to job %s", len(batch), job.Id)
 		_, err = e.Session.AddBatchToJob(string(updates), job)
 		if err != nil {
 			return fmt.Errorf("Failed to enqueue batch: %w", err)
@@ -262,7 +262,7 @@ RECORDS:
 				if err != nil {
 					return job, err
 				}
-				log.Infof("Created job %s\n", job.Id)
+				log.Infof("Created job %s", job.Id)
 			}
 			batch = append(batch, record)
 			if len(batch) == e.BatchSize {


### PR DESCRIPTION
Add --quiet flag to not display info-level log messages.

Remove extra newlines from log messages.
