### PR TITLE
Add changeValue Expr Function

### DIFF
--- a/cmd/batchforce/cmd/root.go
+++ b/cmd/batchforce/cmd/root.go
@@ -68,8 +68,10 @@ var RootCmd = &cobra.Command{
 	  like Apex's String.escapeUnicode method
 	- base64: base-64 encodes input
 	- compareAndSet: check if key maps to value; if key doesn't exist, set it to
-	  value
-	- incr: increments the number stored at key by one. set to 0 if not set.
+	  value (return true unless key already exists with different value)
+	- changeValue: update value associated with key (returns true unless the key
+	  already exists and the value is unchanged)
+	- incr: increments the number stored at key by one. set to 1 if not set.
 
 	The + and - operators can be used to add, update, or remove fields on the
 	record object.  For example:

--- a/expr.go
+++ b/expr.go
@@ -75,7 +75,7 @@ func exprFunctions() []expr.Option {
 		new(func(string) string),
 	))
 
-	store := make(map[string]any)
+	compareAndSetStore := make(map[string]any)
 	// compareAndSet takes a key and value
 	// returns true if the key exists in the store and the stored value matches the passed value
 	// returns true if the key does not exist in the store, and stores the value under the key
@@ -85,14 +85,33 @@ func exprFunctions() []expr.Option {
 		func(params ...any) (any, error) {
 			key := params[0].(string)
 			value := params[1]
-			if store[key] == value {
+			if compareAndSetStore[key] == value {
 				return true, nil
-			} else if _, ok := store[key]; !ok {
-				store[key] = value
+			} else if _, ok := compareAndSetStore[key]; !ok {
+				compareAndSetStore[key] = value
 				return true, nil
 			} else {
 				return false, nil
 			}
+		},
+		new(func(string, any) bool),
+	))
+
+	changeValueStore := make(map[string]any)
+	// changeValue takes a key and value
+	// returns true if the key exists did not already exist
+	// returns true if the key already exists in the store, and the new value is different that the previous value
+	// returns false if the key exists in the store and the stored value is the same as passed value
+	exprFunctions = append(exprFunctions, expr.Function(
+		"changeValue",
+		func(params ...any) (any, error) {
+			key := params[0].(string)
+			value := params[1]
+			if changeValueStore[key] == value {
+				return false, nil
+			}
+			changeValueStore[key] = value
+			return true, nil
 		},
 		new(func(string, any) bool),
 	))


### PR DESCRIPTION
Add a changeValue expr function that updates a key-value store.  It
returns true if the key didn't previously exist or if the new value
changes the value stored.  It returns false if the value passed matches
the existing value for the key.
